### PR TITLE
Atributo nome adicionado na classe AlteraComidaDTO

### DIFF
--- a/src/main/java/br/com/cardapio/dto/AlteraComidaDTO.java
+++ b/src/main/java/br/com/cardapio/dto/AlteraComidaDTO.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class AlteraComidaDTO {
 
+    private String titulo;
     private String descricao;
     private String imagem;
     private Double valor;


### PR DESCRIPTION
## Contexto

Foi adicionado o atributo 'titulo' na classe AlteraComidaDTO.

<br/>

## Descrição

O atributo 'titulo' na classe AlteraComidaDTO, estava pendente. Já que o usuário pode precisar alterar o nome do objeto, caso tenha cadastrado com erro de digitação. Com o atributo adicionado, a alteração do objeto será de acordo com o cenário.


<br/>

## Mudanças na base de código

O atributo foi adicionado na classe DTO, nenhuma outra mudança foi precisa. 

<br/>

## Mudanças fora da base de código

Não houve mudanças fora da base do código.

<br/>

## Informações adicionais

Entendendo o motivo da adição do atributo:

A chave primária da classe Comida é o seu Id, no método alteraComida, é usado uma entrada de dados "titulo" como busca no banco de dados, em um cenário que procuramos o objeto "Lasanha" e alteramos para "Japonês" será finalizado com sucesso e ao procurar "Lasanha" novamente, lançará uma exeção de "Recurso não encontrado". O Id nos protege, o objeto permace com o mesmo Id, alterando apenas o seu titulo.
