### PR TITLE
Cenários de teste para método DeletaComida em CardapioServiceTest

### DIFF
--- a/src/test/java/br/com/cardapio/service/CardapioServiceTest.java
+++ b/src/test/java/br/com/cardapio/service/CardapioServiceTest.java
@@ -13,12 +13,11 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -147,5 +146,31 @@ import static org.mockito.Mockito.when;
         assertEquals("Prato não encontrado", exception.getMessage());
     }
 
-}
+    @Test
+    void testDeletaComidaSucess() {
+            String titulo = "Lasanha";
+            Comida comidaMock = new Comida();
+            comidaMock.setTitulo(titulo);
 
+        when(cardapioRepository.findByTituloIgnoreCase(titulo)).thenReturn(comidaMock);
+
+        assertDoesNotThrow(() -> cardapioService.deletaComida(titulo));
+        Mockito.verify(cardapioRepository).delete(comidaMock);
+
+    }
+
+    @Test
+    void testDeletaComidaException() {
+        String titulo = "Lasanha";
+        when(cardapioRepository.findByTituloIgnoreCase(titulo)).thenThrow(new RecursoNaoEncontradoException("Prato não encontrado"));
+
+        RecursoNaoEncontradoException exception = assertThrows(RecursoNaoEncontradoException.class, () -> {
+            cardapioService.deletaComida(titulo);
+        });
+
+        assertEquals("Prato não encontrado", exception.getMessage());
+        Mockito.verify(cardapioRepository, never()).delete(any());
+    }
+
+
+}


### PR DESCRIPTION
## Contexto

Adicionei novos testes à classe CardapioServiceTest os métodos  'deletaComidaSucess' e 'deletaComidaException', testes do método deletaCOmida da classe 'CardapioService'.

<br/>

## Descrição

Adicionei dois novos testes para garantir que a exclusão de comida funcione corretamente. Um teste verifica se a comida é excluída com sucesso, e o outro verifica se uma mensagem de erro é mostrada quando a comida não é encontrada.
<br/>

## Mudanças na base de código

Um teste verifica se a comida é removida corretamente, o outro se certifica de que uma mensagem de erro é mostrada quando a comida não está cadastrado no banco de dados. Foi adicionado na classe CardapioServiceTest os métodos consecutivamente chamam 'deletaComidaSucess' e 'deletaComidaException', foi usado o framework JUnit Jupiter para o desenvolvimento.

<br/>

## Mudanças fora da base de código

Não foram feitas mudanças fora da base do código.

<br/>


